### PR TITLE
[3.5] Add Orchestra\Testbench\Dusk\Concerns\ProvidesDusk trait.

### DIFF
--- a/src/Concerns/Dusk.php
+++ b/src/Concerns/Dusk.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace Orchestra\Testbench\Dusk\Concerns;
+
+use Closure;
+use Exception;
+use Throwable;
+use ReflectionFunction;
+use Laravel\Dusk\Browser;
+use Illuminate\Support\Collection;
+use Laravel\Dusk\Chrome\SupportsChrome;
+use Facebook\WebDriver\Remote\RemoteWebDriver;
+
+trait Dusk
+{
+    use SupportsChrome;
+
+    /**
+     * All of the active browser instances.
+     *
+     * @var array
+     */
+    protected static $browsers = [];
+
+    /**
+     * The callbacks that should be run on class tear down.
+     *
+     * @var array
+     */
+    protected static $afterClassCallbacks = [];
+
+    /**
+     * Setup the browser environment.
+     *
+     * @return void
+     */
+    protected function setUpTheBrowserEnvironment()
+    {
+        Browser::$baseUrl = $this->baseUrl();
+
+        $this->prepareDirectories();
+
+        Browser::$userResolver = function () {
+            return $this->user();
+        };
+    }
+
+    /**
+     * Tear down the Dusk test case class.
+     *
+     * @afterClass
+     *
+     * @return void
+     */
+    public static function tearDownDuskClass()
+    {
+        static::closeAll();
+
+        foreach (static::$afterClassCallbacks as $callback) {
+            $callback();
+        }
+    }
+
+    /**
+     * Create a new browser instance.
+     *
+     * @param  \Closure $callback
+     *
+     * @throws \Exception
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function browse(Closure $callback)
+    {
+        $browsers = $this->createBrowsersFor($callback);
+
+        try {
+            $callback(...$browsers->all());
+        } catch (Exception $e) {
+            $this->captureFailuresFor($browsers);
+            throw $e;
+        } catch (Throwable $e) {
+            $this->captureFailuresFor($browsers);
+            throw $e;
+        } finally {
+            $this->storeConsoleLogsFor($browsers);
+            static::$browsers = $this->closeAllButPrimary($browsers);
+        }
+    }
+
+    /**
+     * Create the browser instances needed for the given callback.
+     *
+     * @param  \Closure $callback
+     *
+     * @return array
+     */
+    protected function createBrowsersFor(Closure $callback)
+    {
+        if (count(static::$browsers) === 0) {
+            static::$browsers = collect([$this->newBrowser($this->createWebDriver())]);
+        }
+
+        $additional = $this->browsersNeededFor($callback) - 1;
+
+        for ($i = 0; $i < $additional; $i++) {
+            static::$browsers->push($this->newBrowser($this->createWebDriver()));
+        }
+
+        return static::$browsers;
+    }
+
+    /**
+     * Create a new Browser instance.
+     *
+     * @param  \Facebook\WebDriver\Remote\RemoteWebDriver $driver
+     *
+     * @return \Laravel\Dusk\Browser
+     */
+    protected function newBrowser($driver)
+    {
+        return new Browser($driver);
+    }
+
+    /**
+     * Get the number of browsers needed for a given callback.
+     *
+     * @param  \Closure $callback
+     *
+     * @return int
+     */
+    protected function browsersNeededFor(Closure $callback)
+    {
+        return (new ReflectionFunction($callback))->getNumberOfParameters();
+    }
+
+    /**
+     * Capture failure screenshots for each browser.
+     *
+     * @param  \Illuminate\Support\Collection $browsers
+     *
+     * @return void
+     */
+    protected function captureFailuresFor($browsers)
+    {
+        $browsers->each(function ($browser, $key) {
+            $browser->screenshot('failure-'.$this->getName().'-'.$key);
+        });
+    }
+
+    /**
+     * Store the console output for the given browsers.
+     *
+     * @param  \Illuminate\Support\Collection $browsers
+     *
+     * @return void
+     */
+    protected function storeConsoleLogsFor($browsers)
+    {
+        $browsers->each(function ($browser, $key) {
+            $browser->storeConsoleLog($this->getName().'-'.$key);
+        });
+    }
+
+    /**
+     * Close all of the browsers except the primary (first) one.
+     *
+     * @param  \Illuminate\Support\Collection $browsers
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function closeAllButPrimary($browsers)
+    {
+        $browsers->slice(1)->each->quit();
+
+        return $browsers->take(1);
+    }
+
+    /**
+     * Close all of the active browsers.
+     *
+     * @return void
+     */
+    public static function closeAll()
+    {
+        Collection::make(static::$browsers)->each->quit();
+
+        static::$browsers = new Collection();
+    }
+
+    /**
+     * Create the remote web driver instance.
+     *
+     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     */
+    protected function createWebDriver()
+    {
+        return retry(5, function () {
+            return $this->driver();
+        }, 50);
+    }
+
+    /**
+     * Ensure the directories we need for dusk exist, and set them for the Browser to use.
+     *
+     * @return void
+     */
+    protected function prepareDirectories()
+    {
+        $tests = $this->resolveBrowserTestsPath();
+
+        foreach (['/screenshots', '/console'] as $dir) {
+            if (! is_dir($tests.$dir)) {
+                mkdir($tests.$dir, 0777, true);
+            }
+        }
+
+        Browser::$storeScreenshotsAt = $tests.'/screenshots';
+        Browser::$storeConsoleLogAt = $tests.'/console';
+    }
+
+    /**
+     * Figure out where the test directory is, if we're an included package, or the root one.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function resolveBrowserTestsPath($path = __DIR__)
+    {
+        $path = dirname($path);
+
+        // If we're in 'vendor', we need to drop back two levels to project root
+        if (basename(dirname(dirname($path))) == 'vendor') {
+            $path = dirname(dirname(dirname($path)));
+        }
+
+        return $path.'/tests/Browser';
+    }
+
+    /**
+     * Create the RemoteWebDriver instance.
+     *
+     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
+     */
+    abstract protected function driver();
+
+    /**
+     * Determine the application's base URL.
+     *
+     * @var string
+     */
+    abstract protected function baseUrl();
+
+    /**
+     * Get a callback that returns the default user to authenticate.
+     *
+     * @throws \Exception
+     *
+     * @return \Closure
+     */
+    abstract protected function user();
+}

--- a/src/Concerns/ProvidesDusk.php
+++ b/src/Concerns/ProvidesDusk.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Collection;
 use Laravel\Dusk\Chrome\SupportsChrome;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 
-trait Dusk
+trait ProvidesDusk
 {
     use SupportsChrome;
 

--- a/src/Foundation.php
+++ b/src/Foundation.php
@@ -4,32 +4,14 @@ namespace Orchestra\Testbench\Dusk;
 
 use Closure;
 use Exception;
-use Throwable;
-use ReflectionFunction;
-use Laravel\Dusk\Browser;
 use Orchestra\Testbench\TestCase;
-use Illuminate\Support\Collection;
-use Laravel\Dusk\Chrome\SupportsChrome;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 
 abstract class Foundation extends TestCase
 {
     use Concerns\CanServeSite,
-        SupportsChrome;
-
-    /**
-     * All of the active browser instances.
-     *
-     * @var array
-     */
-    protected static $browsers = [];
-    /**
-     * The callbacks that should be run on class tear down.
-     *
-     * @var array
-     */
-    protected static $afterClassCallbacks = [];
+        Concerns\Dusk;
 
     /**
      * Register the base URL with Dusk.
@@ -40,29 +22,7 @@ abstract class Foundation extends TestCase
     {
         parent::setUp();
 
-        Browser::$baseUrl = $this->baseUrl();
-
-        $this->prepareDirectories();
-
-        Browser::$userResolver = function () {
-            return $this->user();
-        };
-    }
-
-    /**
-     * Tear down the Dusk test case class.
-     *
-     * @afterClass
-     *
-     * @return void
-     */
-    public static function tearDownDuskClass()
-    {
-        static::closeAll();
-
-        foreach (static::$afterClassCallbacks as $callback) {
-            $callback();
-        }
+        $this->setUpTheBrowserEnvironment();
     }
 
     /**
@@ -75,146 +35,6 @@ abstract class Foundation extends TestCase
     public static function afterClass(Closure $callback)
     {
         static::$afterClassCallbacks[] = $callback;
-    }
-
-    /**
-     * Create a new browser instance.
-     *
-     * @param  \Closure $callback
-     *
-     * @throws \Exception
-     * @throws \Throwable
-     *
-     * @return void
-     */
-    public function browse(Closure $callback)
-    {
-        $browsers = $this->createBrowsersFor($callback);
-
-        try {
-            $callback(...$browsers->all());
-        } catch (Exception $e) {
-            $this->captureFailuresFor($browsers);
-            throw $e;
-        } catch (Throwable $e) {
-            $this->captureFailuresFor($browsers);
-            throw $e;
-        } finally {
-            $this->storeConsoleLogsFor($browsers);
-            static::$browsers = $this->closeAllButPrimary($browsers);
-        }
-    }
-
-    /**
-     * Create the browser instances needed for the given callback.
-     *
-     * @param  \Closure $callback
-     *
-     * @return array
-     */
-    protected function createBrowsersFor(Closure $callback)
-    {
-        if (count(static::$browsers) === 0) {
-            static::$browsers = collect([$this->newBrowser($this->createWebDriver())]);
-        }
-
-        $additional = $this->browsersNeededFor($callback) - 1;
-
-        for ($i = 0; $i < $additional; $i++) {
-            static::$browsers->push($this->newBrowser($this->createWebDriver()));
-        }
-
-        return static::$browsers;
-    }
-
-    /**
-     * Create a new Browser instance.
-     *
-     * @param  \Facebook\WebDriver\Remote\RemoteWebDriver $driver
-     *
-     * @return \Laravel\Dusk\Browser
-     */
-    protected function newBrowser($driver)
-    {
-        return new Browser($driver);
-    }
-
-    /**
-     * Get the number of browsers needed for a given callback.
-     *
-     * @param  \Closure $callback
-     *
-     * @return int
-     */
-    protected function browsersNeededFor(Closure $callback)
-    {
-        return (new ReflectionFunction($callback))->getNumberOfParameters();
-    }
-
-    /**
-     * Capture failure screenshots for each browser.
-     *
-     * @param  \Illuminate\Support\Collection $browsers
-     *
-     * @return void
-     */
-    protected function captureFailuresFor($browsers)
-    {
-        $browsers->each(function ($browser, $key) {
-            $browser->screenshot('failure-'.$this->getName().'-'.$key);
-        });
-    }
-
-    /**
-     * Store the console output for the given browsers.
-     *
-     * @param  \Illuminate\Support\Collection $browsers
-     *
-     * @return void
-     */
-    protected function storeConsoleLogsFor($browsers)
-    {
-        $browsers->each(function ($browser, $key) {
-            $browser->storeConsoleLog($this->getName().'-'.$key);
-        });
-    }
-
-    /**
-     * Close all of the browsers except the primary (first) one.
-     *
-     * @param  \Illuminate\Support\Collection $browsers
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    protected function closeAllButPrimary($browsers)
-    {
-        $browsers->slice(1)->each->quit();
-
-        return $browsers->take(1);
-    }
-
-    /**
-     * Close all of the active browsers.
-     *
-     * @return void
-     */
-    public static function closeAll()
-    {
-        Collection::make(static::$browsers)->each->quit();
-
-        static::$browsers = collect();
-    }
-
-    /**
-     * Create the remote web driver instance.
-     *
-     * @return \Facebook\WebDriver\Remote\RemoteWebDriver
-     */
-    protected function createWebDriver()
-    {
-        return retry(5, function () {
-            return $this->driver();
-        }, 50);
     }
 
     /**
@@ -249,41 +69,5 @@ abstract class Foundation extends TestCase
     protected function user()
     {
         throw new Exception('User resolver has not been set.');
-    }
-
-    /**
-     * Ensure the directories we need for dusk exist, and set them for the Browser to use.
-     */
-    protected function prepareDirectories()
-    {
-        $tests = $this->resolveBrowserTestsPath();
-
-        foreach (['/screenshots', '/console'] as $dir) {
-            if (! is_dir($tests.$dir)) {
-                mkdir($tests.$dir, 0777, true);
-            }
-        }
-
-        Browser::$storeScreenshotsAt = $tests.'/screenshots';
-        Browser::$storeConsoleLogAt = $tests.'/console';
-    }
-
-    /**
-     * Figure out where the test directory is, if we're an included package, or the root one.
-     *
-     * @param string $path
-     *
-     * @return string
-     */
-    protected function resolveBrowserTestsPath($path = __DIR__)
-    {
-        $path = dirname($path);
-
-        // If we're in 'vendor', we need to drop back two levels to project root
-        if (basename(dirname(dirname($path))) == 'vendor') {
-            $path = dirname(dirname(dirname($path)));
-        }
-
-        return $path.'/tests/Browser';
     }
 }

--- a/src/Foundation.php
+++ b/src/Foundation.php
@@ -11,7 +11,7 @@ use Facebook\WebDriver\Remote\DesiredCapabilities;
 abstract class Foundation extends TestCase
 {
     use Concerns\CanServeSite,
-        Concerns\Dusk;
+        Concerns\ProvidesDusk;
 
     /**
      * Register the base URL with Dusk.

--- a/tests/Unit/FoundationTest.php
+++ b/tests/Unit/FoundationTest.php
@@ -2,8 +2,8 @@
 
 namespace Orchestra\Testbench\Dusk\Tests\Unit;
 
-use Orchestra\Testbench\Dusk\Foundation;
 use PHPUnit\Framework\TestCase;
+use Orchestra\Testbench\Dusk\Foundation;
 
 class FoundationTest extends TestCase
 {


### PR DESCRIPTION
This class would contain minimal requirement to use chrome web driver on any local or remote browser testing.

I want a quick way to run complete application availability for my app (useful after big deployment, database maintenance). Loading and serving Laravel isn't useful here since the request is mainly remote.