### PR TITLE
change process STDERR to pipe

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -118,7 +118,7 @@ class DuskServer
     {
         $this->pointer = proc_open(
             $this->prepareCommand(),
-            [1 => ['pipe', 'w']],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
             $this->pipes,
             $this->laravelPublicPath()
         );


### PR DESCRIPTION
post STDERR in pipe for hide all 200 GET outputs from cli. Laravel dusk alrady handle console errors.