### PR TITLE
Improve server management [3.5]

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -4,7 +4,6 @@ namespace Orchestra\Testbench\Dusk;
 
 use Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
 use Symfony\Component\Process\PhpExecutableFinder;
 
 class DuskServer
@@ -159,10 +158,10 @@ class DuskServer
     {
         return sprintf(
             'exec %s -S %s:%s %s',
-            ProcessUtils::escapeArgument((new PhpExecutableFinder())->find(false)),
+            (new PhpExecutableFinder())->find(false),
             $this->host,
             $this->port,
-            ProcessUtils::escapeArgument(__DIR__ . '/server.php')
+            __DIR__ . '/server.php'
         );
     }
 
@@ -180,7 +179,7 @@ class DuskServer
         $root = dirname(dirname($root ?: __DIR__));
 
         // Check if we're working on this package. If we are, shimmy to the vendor dir.
-        if (!basename(dirname($root)) == 'vendor') {
+        if (! basename(dirname($root)) == 'vendor') {
             $root .= '/testbench-dusk/vendor/orchestra';
         }
 

--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -11,7 +11,7 @@ class DuskServer
     /**
      * Process pointer reference.
      *
-     * @var object
+     * @var resource
      */
     protected $pointer;
 
@@ -88,6 +88,7 @@ class DuskServer
      * Start a php server in a separate process.
      *
      * @return void
+     * @throws \Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer
      */
     public function start()
     {
@@ -113,7 +114,12 @@ class DuskServer
             return;
         }
 
+        $pointer = $this->pointer;
         proc_terminate($this->pointer);
+
+        while (proc_get_status($pointer)['running'] ?? false == true) {
+            // wait
+        }
     }
 
     /**
@@ -122,6 +128,7 @@ class DuskServer
      * not relevant for us during our testing.
      *
      * @return void
+     * @throws \Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer
      */
     protected function startServer()
     {
@@ -129,7 +136,10 @@ class DuskServer
 
         $this->pointer = proc_open(
             $this->prepareCommand(),
-            [1 => ['pipe', 'w']],
+            [
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
             $this->pipes,
             $this->laravelPublicPath()
         );

--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -158,7 +158,7 @@ class DuskServer
     protected function prepareCommand()
     {
         return sprintf(
-            '%s -S %s:%s %s',
+            'exec %s -S %s:%s %s',
             ProcessUtils::escapeArgument((new PhpExecutableFinder())->find(false)),
             $this->host,
             $this->port,

--- a/src/Exceptions/UnableToStartServer.php
+++ b/src/Exceptions/UnableToStartServer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orchestra\Testbench\Dusk\Exceptions;
+
+use Exception;
+use Throwable;
+
+class UnableToStartServer extends Exception
+{
+    public function __construct(string $message = "", int $code = 0, Throwable $previous = null)
+    {
+        $fullMessage = "A server is already running on {$message}. Please stop it before proceeding. \n" .
+            "It is likely to be a php server, so you can search your existing processes for 'php -L'. \n" .
+            "Alternatively you can change the setup for your tests to use a different host and port.";
+
+        parent::__construct($fullMessage, $code, $previous);
+    }
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -29,6 +29,7 @@ abstract class TestCase extends Foundation
     {
         $options = (new ChromeOptions())->addArguments([
             '--disable-gpu',
+            '--headless',
         ]);
 
         return RemoteWebDriver::create(

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -34,13 +34,14 @@ class DuskServerTest extends TestCase
             $b = new DuskServer;
 
             $a->start();
-            sleep(1);
+            $this->waitForServerToStart();
 
             $b->start();
 
         } catch (UnableToStartServer $e) {
             $a->stop();
             $b->stop();
+            $this->waitForServerToStop();
             $this->assertTrue(true, 'New server was not created with the same host and port');
 
             return;
@@ -48,6 +49,8 @@ class DuskServerTest extends TestCase
 
         $a->stop();
         $b->stop();
+
+        $this->waitForServerToStop();
 
         $this->fail('A server existed but we tried to set a new one up anyway');
     }
@@ -65,13 +68,12 @@ class DuskServerTest extends TestCase
                 // So create a server and exit (to simluate a dd() or similar in a test)
                 // Once complete, the parent can check for the orpahn server.
                 (new DuskServer)->start();
-                sleep(1);
+                $this->waitForServerToStart();
                 exit();
                 break;
             default:
                 // @parent
                 pcntl_waitpid($pid, $status);
-                sleep(2);
                 try {
                     (new DuskServer)->start();
                     $this->assertTrue(true, 'We did not end up with an orphan server');
@@ -80,5 +82,43 @@ class DuskServerTest extends TestCase
                 }
                 break;
         }
+    }
+
+    protected function waitForServerToStart()
+    {
+        $i = 0;
+
+        while (! $this->isServerUp()) {
+            sleep(1);
+            $i++;
+
+            if($i >= 10) {
+                throw new \Exception('Waited too long for server to start.');
+            }
+        }
+    }
+
+    protected function waitForServerToStop()
+    {
+        $i = 0;
+
+        while ($this->isServerUp()) {
+            sleep(1);
+            $i++;
+
+            if ($i >= 10) {
+                throw new \Exception('Waited too long for server to stop.');
+            }
+        }
+    }
+
+    protected function isServerUp()
+    {
+        if ($socket = @fsockopen('127.0.0.1', 8000, $errorNumber = 0, $errorString = '', $timeout = 1)) {
+            fclose($socket);
+            return true;
+        }
+
+        return false;
     }
 }

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -2,6 +2,7 @@
 
 namespace Orchestra\Testbench\Dusk\Tests\Unit;
 
+use Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer;
 use PHPUnit\Framework\TestCase;
 use Orchestra\Testbench\Dusk\DuskServer;
 
@@ -23,5 +24,60 @@ class DuskServerTest extends TestCase
             '/dir/project/vendor/orchestra/testbench-core/laravel/public',
             (new DuskServer())->laravelPublicPath('/dir/project/vendor/orchestra/testbench-dusk/src')
         );
+    }
+
+    /** @test */
+    public function it_fails_when_there_is_a_server_on_the_host_and_port_already()
+    {
+        try {
+            $a = new DuskServer;
+            $b = new DuskServer;
+
+            $a->start();
+            sleep(1);
+
+            $b->start();
+
+        } catch (UnableToStartServer $e) {
+            $a->stop();
+            $b->stop();
+            $this->assertTrue(true, 'New server was not created with the same host and port');
+
+            return;
+        }
+
+        $a->stop();
+        $b->stop();
+
+        $this->fail('A server existed but we tried to set a new one up anyway');
+    }
+
+    /** @test */
+    public function an_early_exit_does_not_leave_an_orphan_server()
+    {
+        switch ($pid = pcntl_fork()) {
+            case -1:
+                $this->fail('Process fork failed when testing for an orphan server');
+                break;
+            case 0:
+                // @child
+                // We have everything from the scrip so far available
+                // So create a server and exit (to simluate a dd() or similar in a test)
+                // Once complete, the parent can check for the orpahn server.
+                (new DuskServer)->start();
+                sleep(1);
+                exit();
+                break;
+            default:
+                // @parent
+                pcntl_waitpid($pid, $status);
+                try {
+                    (new DuskServer)->start();
+                    $this->assertTrue(true, 'We did not end up with an orphan server');
+                } catch (UnableToStartServer $e) {
+                    $this->fail('There was an orphan server. You\'ll need to remove it manually.');
+                }
+                break;
+        }
     }
 }

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -92,7 +92,7 @@ class DuskServerTest extends TestCase
             sleep(1);
             $i++;
 
-            if($i >= 10) {
+            if($i >= 30) {
                 throw new \Exception('Waited too long for server to start.');
             }
         }
@@ -106,7 +106,7 @@ class DuskServerTest extends TestCase
             sleep(1);
             $i++;
 
-            if ($i >= 10) {
+            if ($i >= 30) {
                 throw new \Exception('Waited too long for server to stop.');
             }
         }

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -71,6 +71,7 @@ class DuskServerTest extends TestCase
             default:
                 // @parent
                 pcntl_waitpid($pid, $status);
+                sleep(2);
                 try {
                     (new DuskServer)->start();
                     $this->assertTrue(true, 'We did not end up with an orphan server');

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -40,7 +40,7 @@ class DuskServerTest extends TestCase
 
         } catch (UnableToStartServer $e) {
             $a->stop();
-            $b->stop();
+
             $this->waitForServerToStop();
             $this->assertTrue(true, 'New server was not created with the same host and port');
 
@@ -64,7 +64,7 @@ class DuskServerTest extends TestCase
                 break;
             case 0:
                 // @child
-                // We have everything from the scrip so far available
+                // We have everything from the script so far available
                 // So create a server and exit (to simluate a dd() or similar in a test)
                 // Once complete, the parent can check for the orpahn server.
                 (new DuskServer)->start();


### PR DESCRIPTION
- Be more cautious with using/creating Dusk server. Fail if a server (or process) already exists on the host/port we want to use.
- Add a shutdown_function to handle stopping the server if the test is prematurely closed (e.g. dd() or exit()).
- Swap to using the Symfony Process class for starting and stopping the separate server process. Allows us to remove ProcessUtils as well.
- Add 'exec' to the process command, which allows a clean shutdown on Ubuntu (found through Travis). (Relevant bug report for Symfony here: symfony/symfony#23568)