### PR TITLE
Fix/find correct root path [3.5]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "php": ">=7.0",
         "facebook/webdriver": "~1.3",
         "jeremeamia/superclosure": "^2.3",
+        "konsulting/project-root": "dev-master",
         "laravel/dusk": "~2.0.11",
         "orchestra/testbench": "~3.5.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "php": ">=7.0",
         "facebook/webdriver": "~1.3",
         "jeremeamia/superclosure": "^2.3",
-        "konsulting/project-root": "dev-master",
+        "konsulting/project-root": "~1.0",
         "laravel/dusk": "~2.0.11",
         "orchestra/testbench": "~3.5.2"
     },

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -5,6 +5,7 @@ namespace Orchestra\Testbench\Dusk\Concerns;
 use Laravel\Dusk\Browser;
 use Laravel\Dusk\Chrome\SupportsChrome;
 use Laravel\Dusk\Concerns\ProvidesBrowser as Concern;
+use Konsulting\ProjectRoot;
 
 trait ProvidesBrowser
 {
@@ -52,17 +53,11 @@ trait ProvidesBrowser
      * @param string $path
      *
      * @return string
+     * @throws \Exception
      */
     protected function resolveBrowserTestsPath($path = __DIR__)
     {
-        $path = dirname($path);
-
-        // If we're in 'vendor', we need to drop back two levels to project root
-        if (basename(dirname(dirname($path))) == 'vendor') {
-            $path = dirname(dirname(dirname($path)));
-        }
-
-        return $path.'/tests/Browser';
+        return ProjectRoot::forPackage('testbench-dusk')->resolve($path).'/tests/Browser';
     }
 
     /**


### PR DESCRIPTION
Testbench Dusk was placing screenshots and console output from tests in the wrong place.

This PR pulls in a small utility (https://github.com/konsulting/project-root) class that performs the logic to find the working 'root' for how we're using the package (as a dependency, or itself).

It also stops the creation of directories in the wrong place during the test to validate the location logic - which is currently caused by the setup methods of the test case.