### PR TITLE
Resolve issues with Travis tests failing inconsistently

### DIFF
--- a/src/Concerns/CanServeSite.php
+++ b/src/Concerns/CanServeSite.php
@@ -11,7 +11,7 @@ trait CanServeSite
     /**
      * The server implementation.
      *
-     * @var \Orchestra\Testbench\DuskServer
+     * @var \Orchestra\Testbench\Dusk\DuskServer
      */
     protected static $server;
 
@@ -20,9 +20,13 @@ trait CanServeSite
      *
      * @param string $host
      * @param int    $port
+     *
+     * @throws \Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer
      */
     public static function serve($host = '127.0.0.1', $port = 8000)
     {
+        static::stopServing();
+
         $server = new DuskServer($host, $port);
         $server->stash(['class' => static::class]);
         $server->start();
@@ -88,7 +92,7 @@ trait CanServeSite
      * replicate the Application state during a Dusk test when we start our
      * test server. See the main server file 'server.php'.
      *
-     * @param \Orchestra\Testbench\DuskServer $server
+     * @param \Orchestra\Testbench\Dusk\DuskServer $server
      *
      * @return \Illuminate\Foundation\Application
      */
@@ -106,5 +110,15 @@ trait CanServeSite
         }
 
         return $this->app;
+    }
+
+    /**
+     * Return the current instance of server
+     *
+     * @return \Orchestra\Testbench\Dusk\DuskServer|null
+     */
+    public function getServer()
+    {
+        return static::$server;
     }
 }

--- a/src/Concerns/ProvidesBrowser.php
+++ b/src/Concerns/ProvidesBrowser.php
@@ -16,6 +16,7 @@ trait ProvidesBrowser
      * Setup the browser environment.
      *
      * @return void
+     * @throws \Exception
      */
     protected function setUpTheBrowserEnvironment()
     {
@@ -32,6 +33,7 @@ trait ProvidesBrowser
      * Ensure the directories we need for dusk exist, and set them for the Browser to use.
      *
      * @return void
+     * @throws \Exception
      */
     protected function prepareDirectories()
     {

--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -180,4 +180,14 @@ class DuskServer
     {
         return $root ?: realpath(__DIR__.'/../laravel/public');
     }
+
+    /**
+     * Get the current process
+     *
+     * @return \Symfony\Component\Process\Process|null
+     */
+    public function getProcess()
+    {
+        return $this->process;
+    }
 }

--- a/tests/Unit/Concerns/CanServeSiteTest.php
+++ b/tests/Unit/Concerns/CanServeSiteTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Orchestra\Testbench\Dusk\Tests\Unit\Concerns;
+
+use Orchestra\Testbench\Dusk\Tests\Unit\TestCase;
+use Orchestra\Testbench\Dusk\Concerns\CanServeSite;
+
+class CanServeSiteTest extends TestCase
+{
+    /** @test * */
+    public function it_starts_and_stops_a_server()
+    {
+        $dummy = new CanServeSiteDummy;
+
+        $dummy::serve('127.0.0.1', 8000);
+
+        $this->assertFalse($dummy->getServer()->getProcess()->isTerminated());
+
+        // It can take a little time to get up and running.
+        $this->waitForServerToStart();
+        $this->assertTrue($this->isServerUp());
+
+        $dummy::stopServing();
+        $this->waitForServerToStop();
+
+        $this->assertTrue($dummy->getServer()->getProcess()->isTerminated());
+        $this->assertFalse($this->isServerUp());
+    }
+
+    /** @test * */
+    public function it_stops_an_existing_server_and_starts_a_new_one_with_consecutive_serve_requests()
+    {
+        $dummy = new CanServeSiteDummy;
+
+        $dummy::serve('127.0.0.1', 8000);
+
+        $duskServerOne = $dummy->getServer();
+        // we don't bother waiting since that is tested in 'it_starts_and_stops_a_server'
+
+        $dummy::serve('127.0.0.1', 8000);
+
+        $duskServerTwo = $dummy->getServer();
+
+        $this->assertNotSame($duskServerOne, $duskServerTwo);
+        $this->assertTrue($duskServerOne->getProcess()->isTerminated());
+        $this->assertFalse($duskServerTwo->getProcess()->isTerminated());
+
+        $dummy::stopServing();
+    }
+}
+
+class CanServeSiteDummy
+{
+    use CanServeSite;
+}

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -2,7 +2,6 @@
 
 namespace Orchestra\Testbench\Dusk\Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
 use Orchestra\Testbench\Dusk\DuskServer;
 use Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer;
 
@@ -81,44 +80,5 @@ class DuskServerTest extends TestCase
                 }
                 break;
         }
-    }
-
-    protected function waitForServerToStart()
-    {
-        $i = 0;
-
-        while (! $this->isServerUp()) {
-            sleep(1);
-            $i++;
-
-            if ($i >= 30) {
-                throw new \Exception('Waited too long for server to start.');
-            }
-        }
-    }
-
-    protected function waitForServerToStop()
-    {
-        $i = 0;
-
-        while ($this->isServerUp()) {
-            sleep(1);
-            $i++;
-
-            if ($i >= 30) {
-                throw new \Exception('Waited too long for server to stop.');
-            }
-        }
-    }
-
-    protected function isServerUp()
-    {
-        if ($socket = @fsockopen('127.0.0.1', 8000, $errorNumber = 0, $errorString = '', $timeout = 1)) {
-            fclose($socket);
-
-            return true;
-        }
-
-        return false;
     }
 }

--- a/tests/Unit/ResolvesProjectRootTest.php
+++ b/tests/Unit/ResolvesProjectRootTest.php
@@ -34,4 +34,15 @@ class DummyTestCase extends TestbenchDuskTestCase
     {
         $this->assertTrue(true);
     }
+
+    // Don't try to start another server!
+    public static function setUpBeforeClass() {
+        //
+    }
+
+    // Don't need to stop a server
+    public static function tearDownAfterClass()
+    {
+        //
+    }
 }

--- a/tests/Unit/TestCase.php
+++ b/tests/Unit/TestCase.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Orchestra\Testbench\Dusk\Tests\Unit;
+
+use Exception;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+class TestCase extends PHPUnitTestCase
+{
+    protected function waitForServerToStart()
+    {
+        $i = 0;
+
+        while (!$this->isServerUp()) {
+            sleep(1);
+            $i++;
+
+            if ($i >= 5) {
+                throw new Exception('Waited too long for server to start.');
+            }
+        }
+    }
+
+    protected function waitForServerToStop()
+    {
+        $i = 0;
+
+        while ($this->isServerUp()) {
+            sleep(1);
+            $i++;
+
+            if ($i >= 5) {
+                throw new Exception('Waited too long for server to stop.');
+            }
+        }
+    }
+
+    protected function isServerUp()
+    {
+        if ($socket = @fsockopen('127.0.0.1', 8000, $errorNumber = 0, $errorString = '', $timeout = 1)) {
+            fclose($socket);
+
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
 - The DummyTestCase used to check resolving browser test paths
   was trying to spool up the server a second time.  Stopped by overriding
   setUpBeforeClass and tearDownAfterClass.

 - Also added a guard to CanServeSite::serve() to stop serving, if asked to
   serve again.

 - Added getters to CanServeSite and DuskServer to get the Symfony/Process
   and the DuskServer instance if needed (e.g. testing).

 - Added tests to verify server being started and stopped, and that new
   guard above works correctly.