### PR TITLE
Quit all browsers upon early termination.

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -29,6 +29,13 @@ abstract class TestCase extends Foundation
     protected static $baseServePort = 8000;
 
     /**
+     * Keep track of whether we've registered shutdown function
+     *
+     * @var bool
+     */
+    protected static $hasRegisteredShutdown = false;
+
+    /**
      * Register the base URL with Dusk.
      *
      * @return void
@@ -38,6 +45,24 @@ abstract class TestCase extends Foundation
         parent::setUp();
 
         $this->setUpTheBrowserEnvironment();
+        $this->registerShutdownFunction();
+    }
+
+    /**
+     * Make sure we close down any chrome processes when we temrinate early, unlike normal
+     * Dusk, we also close down all the server processes - so keeping the chome browser
+     * open doesn't help, nor does it help when we're running in headless mode :)
+     *
+     */
+    protected function registerShutdownFunction()
+    {
+        if (!static::$hasRegisteredShutdown) {
+            register_shutdown_function(function () {
+                $this->closeAll();
+            });
+
+            static::$hasRegisteredShutdown = true;
+        }
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -53,6 +53,7 @@ abstract class TestCase extends Foundation
      * Dusk, we also close down all the server processes - so keeping the chome browser
      * open doesn't help, nor does it help when we're running in headless mode :)
      *
+     * @return void
      */
     protected function registerShutdownFunction()
     {


### PR DESCRIPTION
This is so exit()-ing within a test doesn't leave chrome processes
hanging around. Since we close the server processes they're not
super useful, and less useful when running in headless mode.