### PR TITLE
Fixed Windows paths to start PHP server

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -159,7 +159,7 @@ class DuskServer
     protected function prepareCommand(): string
     {
         return sprintf(
-            'exec %s -S %s:%s %s',
+            (($this->isWindows() ? '' : 'exec ') .'"%s" -S %s:%s "%s"'),
             (new PhpExecutableFinder())->find(false),
             $this->host,
             $this->port,
@@ -179,6 +179,16 @@ class DuskServer
     public function laravelPublicPath(?string $root = null): string
     {
         return $root ?: realpath(__DIR__.'/../laravel/public');
+    }
+    
+    /**
+     * Check if current OS is Windows.
+     *
+     * @return bool
+     */
+    protected function isWindows()
+    {
+        return strtoupper(substr(PHP_OS, 0, 3)) === 'WIN';
     }
 
     /**


### PR DESCRIPTION
Had to wrap double quotes on the PHP executable path and script path, since Windows CMD need this when the paths have space, like `Program Files` or `My Documents`.

The final output is expected like this:
```cmd
cmd /V:ON /E:ON /D /C ("C:\My PHP\PHP\7.3\php.exe" -S 127.0.0.1:8000 "C:\My Packages\TestPackage\vendor\orchestra\testbench-dusk\src/server.php") 1>"C:\Users\My User\AppData\Local\Temp\sf_proc_01.out" 2>"C:\Users\My User \AppData\Local\Temp\sf_proc_01.err"
```