### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "facebook/webdriver": "^1.7",
+        "php-webdriver/webdriver": "^1.7",
         "konsulting/project-root": "^1.1",
         "laravel/dusk": "^5.6.3",
         "opis/closure": "^3.1",


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```