### PR TITLE
Add screenshots upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,3 +44,9 @@ jobs:
         run: vendor/laravel/dusk/bin/chromedriver-linux &
       - name: Execute tests
         run: vendor/bin/phpunit
+      - name: Upload Failed Screenshots
+        uses: actions/upload-artifact@v2-preview
+        if: failure()
+        with:
+          name: screenshots
+          path: tests/Browser/screenshots/*


### PR DESCRIPTION
I've found it helpful to upload the screenshot to artifacts. Not sure how reliable this is (because it's in preview), but maybe it's useful to add as example.

Example here: https://github.com/fruitcake/laravel-cors/actions/runs/82006780
More info on the upload-artifact/preview: https://github.com/actions/upload-artifact/issues/62