### PR TITLE
Document port change

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ class BrowserTestCase extends Orchestra\Testbench\Dusk\TestCase
 
 ### Custom Host and Port
 
-By default, Tesbench Dusk will start its own PHP server at `http://127.0.0.1:8000`.
+By default, Tesbench Dusk will start its own PHP server at `http://127.0.0.1:8001`.
 
 You can customize this by replacing the `$baseServeHost` and `$baseServePort` such as below:
 


### PR DESCRIPTION
The latest release opens port 8001 by default, this PR only updates the documentation regarding that.