### PR TITLE
Call setUpApplicationRoutes before starting server

### DIFF
--- a/src/Concerns/CanServeSite.php
+++ b/src/Concerns/CanServeSite.php
@@ -140,6 +140,11 @@ trait CanServeSite
         if (! $this->app) {
             $this->refreshApplication();
         }
+        
+        
+        if(in_array('Orchestra\Testbench\Concerns\HandlesRoutes', class_uses_recursive($this))) {
+            $this->setUpApplicationRoutes();
+        }
     }
 
     /**


### PR DESCRIPTION
If we use the testbench HandlesRoutes concern to configure routes with defineRoutes, the routes are registered too late.
Register routes before starting the web server.

fixes #54  Kind of :)