### PR TITLE
On Windows support paths containing spaces

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -190,7 +190,7 @@ class DuskServer
             (new PhpExecutableFinder())->find(false),
             $this->host,
             $this->port,
-            __DIR__.'/server.php'
+            '"'.__DIR__.'/server.php'.'"'
         );
     }
 


### PR DESCRIPTION
If `__DIR__` contains a space, without quotes this command will fail