### PR TITLE
Add Note for Database usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ protected function getEnvironmentSetUp($app)
     $this->app['config']->set('database.default', 'sqlite');
 }
 ```
+**Note:**
+In contradiction with laravel documentation you **should not** use `Illuminate\Foundation\Testing\DatabaseMigrations` trait, as testbench-dusk handles rollbacks by its self
 
 To create the sqlite database you just need to run the following code:
 


### PR DESCRIPTION
Firstly I would like to thank you for this package as it helps a lot to test modular applications and packages

I was struggling a lot according laravel Dusk documentation (as suggested) and using `DatabaseMigrations` trait in my test-cases and couldn't find the error.

Orchestra dusk, handles its self the rollbacks and in combination with the given trait the one works against the other. So I suppose it would be a nice idea to inform future developers, and help them avoid my problem