### PR TITLE
Export `$baseServePort` & `$baseServePort` to methods in order to be able to handle them, based on other variables

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -38,6 +38,23 @@ abstract class TestCase extends Testbench
     protected static $hasRegisteredShutdown = false;
 
     /**
+     * @return int
+     */
+    public static function getBaseServePort()
+    {
+        return static::$baseServePort;
+    }
+
+
+    /**
+     * @return string
+     */
+    public static function getBaseServeHost()
+    {
+        return static::$baseServeHost;
+    }
+
+    /**
      * Get Application's base path.
      *
      * @return string
@@ -56,7 +73,7 @@ abstract class TestCase extends Testbench
      */
     public static function applicationBaseUrl()
     {
-        return sprintf('http://%s:%d', static::$baseServeHost, static::$baseServePort);
+        return sprintf('http://%s:%d', static::getBaseServeHost(), static::getBaseServePort());
     }
 
     /**
@@ -198,7 +215,7 @@ abstract class TestCase extends Testbench
      */
     public static function setUpBeforeClass(): void
     {
-        static::serve(static::$baseServeHost, static::$baseServePort);
+        static::serve(static::getBaseServeHost(), static::getBaseServePort());
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -38,6 +38,8 @@ abstract class TestCase extends Testbench
     protected static $hasRegisteredShutdown = false;
 
     /**
+     * The base server port.
+     *
      * @return int
      */
     public static function getBaseServePort()
@@ -47,6 +49,8 @@ abstract class TestCase extends Testbench
 
 
     /**
+     * The base server host.
+     *
      * @return string
      */
     public static function getBaseServeHost()


### PR DESCRIPTION
Using testbench-dusk with Laravel sail & selenium, it needs some custom host configuration, but on github Actions this configuration has to be different (as the browser tests works on same container). 
I suppose having a method instead of property is the best scenario to be able to handle these differences 