### PR TITLE
Wrap PHP binary in quotes

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -186,7 +186,7 @@ class DuskServer
     {
         return sprintf(
             (($this->isWindows() ? '' : 'exec ').'%s -S %s:%s %s'),
-            (new PhpExecutableFinder())->find(false),
+            '"'.(new PhpExecutableFinder())->find(false).'"',
             $this->host,
             $this->port,
             '"'.__DIR__.'/server.php'.'"'


### PR DESCRIPTION
This PR wraps the PHP executable in quotes, adding support for Laravel Herd.

This is related to https://github.com/beyondcode/herd-community/issues/21