### PR TITLE
[6.x] Add `defineChromeDriver()` method

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -273,6 +273,8 @@ abstract class TestCase extends Testbench
     /**
      * Define the ChromeDriver.
      *
+     * @api     
+     *
      * @return void
      *
      * @codeCoverageIgnore

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -277,7 +277,7 @@ abstract class TestCase extends Testbench
      *
      * @codeCoverageIgnore
      */
-    protected static function defineChromeDriver()
+    protected static function defineChromeDriver(): void
     {
         static::startChromeDriver(['port' => 9515]);
     }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -263,11 +263,23 @@ abstract class TestCase extends Testbench
         static::setUpBeforeClassForInteractsWithWebDriverOptions();
 
         if (! isset($_ENV['DUSK_DRIVER_URL'])) {
-            static::startChromeDriver(['port' => 9515]);
+            static::defineChromeDriver();
         }
 
         parent::setUpBeforeClass();
         static::startServing();
+    }
+
+    /**
+     * Define the ChromeDriver.
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected static function defineChromeDriver()
+    {
+        static::startChromeDriver(['port' => 9515]);
     }
 
     /**


### PR DESCRIPTION
This PR adds a `defineChromeDrive()` method to the `TestCase` so it can be overwritten, as discussed in https://github.com/livewire/livewire/pull/8232#issuecomment-2028605729