### PR TITLE
[6.x] Add `defineChromeDriver()` method

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -263,11 +263,23 @@ abstract class TestCase extends Testbench
         static::setUpBeforeClassForInteractsWithWebDriverOptions();
 
         if (! isset($_ENV['DUSK_DRIVER_URL'])) {
-            static::startChromeDriver(['port' => 9515]);
+            static::defineChromeDriver();
         }
 
         parent::setUpBeforeClass();
         static::startServing();
+    }
+
+    /**
+     * Define the ChromeDriver.
+     *
+     * @return void
+     *
+     * @codeCoverageIgnore
+     */
+    protected static function defineChromeDriver()
+    {
+        static::startChromeDriver(['port' => 9515]);
     }
 
     /**


### PR DESCRIPTION
This PR adds a `defineChromeDrive()` method to the `TestCase` so it can be overwritten, as discussed in https://github.com/livewire/livewire/pull/8232#issuecomment-2028605729