### PR TITLE
fix: prevent DuskServer hang when php -S pipe fills

### DIFF
--- a/src/DuskServer.php
+++ b/src/DuskServer.php
@@ -155,24 +155,32 @@ class DuskServer
     /**
      * Clear the php server output.
      *
+     * No-op when output was disabled at start (the default), since
+     * Symfony Process redirects those streams to /dev/null.
+     *
      * @return void
      */
     public function clearOutput(): void
     {
-        if (isset($this->process)) {
-            $this->process->clearOutput();
-            $this->process->clearErrorOutput();
+        if (! isset($this->process) || $this->process->isOutputDisabled()) {
+            return;
         }
+
+        $this->process->clearOutput();
+        $this->process->clearErrorOutput();
     }
 
     /**
      * Start the server. Execute the command and open a
-     * pointer to it. Tuck away the output as it's
-     * not relevant for us during our testing.
+     * pointer to it. Output is discarded: the built-in PHP
+     * server logs every request to stderr, and if that pipe
+     * is never drained it fills and blocks the server.
      *
      * @return void
      *
      * @throws \Orchestra\Testbench\Dusk\Exceptions\UnableToStartServer
+     *
+     * @see https://github.com/orchestral/testbench-dusk/issues/123
      */
     protected function startServer(): void
     {
@@ -188,6 +196,10 @@ class DuskServer
             ]),
             timeout: $this->timeout
         );
+
+        // Discard stdout/stderr so the OS pipe cannot fill and hang php -S
+        // mid-suite when request log volume exceeds the pipe buffer.
+        $this->process->disableOutput();
 
         $this->process->start();
     }

--- a/tests/Unit/DuskServerTest.php
+++ b/tests/Unit/DuskServerTest.php
@@ -64,6 +64,32 @@ class DuskServerTest extends TestCase
     }
 
     #[Test]
+    public function it_disables_process_output_so_the_server_pipe_cannot_fill()
+    {
+        $server = new DuskServer;
+
+        $server->start();
+        $this->waitForServerToStart();
+
+        try {
+            $process = $server->getProcess();
+
+            $this->assertNotNull($process);
+            $this->assertTrue(
+                $process->isOutputDisabled(),
+                'Server process must discard stdout/stderr so php -S cannot block when the pipe fills'
+            );
+
+            // clearOutput must remain safe when output is disabled (called from tearDown).
+            $server->clearOutput();
+            $this->assertTrue($this->isServerUp());
+        } finally {
+            $server->stop();
+            $this->waitForServerToStop();
+        }
+    }
+
+    #[Test]
     public function an_early_exit_does_not_leave_an_orphan_server()
     {
         switch ($pid = pcntl_fork()) {


### PR DESCRIPTION
## Summary

Fixes #123.

`DuskServer::start()` launches `php -S` through a Symfony `Process` whose stdout/stderr were never consumed. The built-in server logs every HTTP request to stderr, so on request-heavy suites the OS pipe buffer fills, `php_cli_server_logf` blocks, and the server stops answering — permanently. The suite then hangs forever instead of failing.

## Changes

- Call `Process::disableOutput()` before `start()` so stdout/stderr go to `/dev/null` instead of an unread pipe.
- Make `clearOutput()` a no-op when output is disabled (it is called from `TestCase::tearDown()` and `restart()`).
- Add a unit test asserting the process has output disabled and that `clearOutput()` remains safe.

## Why `disableOutput()`

This matches the existing intent in `startServer()` (server output is not used during testing) and is the smallest reliable fix. Draining incrementally would also work, but keeps unused log data in memory for the life of the suite.

## Test plan

- [x] `vendor/bin/phpunit --filter 'DuskServerTest|CanServeSiteTest'` — pass
- [x] `vendor/bin/pint --test` — pass
- [x] `vendor/bin/phpstan analyse` — pass
- [ ] Confirm a previously hanging high-traffic Dusk suite (e.g. Livewire `wire:model.live`) now completes